### PR TITLE
Add run helper and setup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.db

--- a/README.md
+++ b/README.md
@@ -1,5 +1,30 @@
-# MB World Project Tracker
+# Pawgress App
 
-This repository contains a minimal PyQt6 application for managing tasks in Mercedes-Benz World projects. The app provides two lists – one for pending tasks and another for completed tasks – backed by a local SQLite database. Tasks can be added with a priority, automatically sorted, and marked as done.
+This repository provides a standalone PyQt6 desktop application used to track
+animal health data and simple project tasks.  It can be placed alongside your
+Unreal Engine `.uproject` file so the application is version controlled with
+the rest of the project.
 
-Run `mb_world_tracker.py` to launch the interface.
+## Requirements
+
+Install the Python dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+Use the `run_app.py` helper which automatically pulls the latest changes from
+the repository and then launches the main application:
+
+```bash
+python run_app.py
+```
+
+The main application code lives in `pawgress.py`.
+
+## Updating
+
+`run_app.py` performs a `git pull` on startup so the application stays in sync
+with the repository whenever it is launched.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PyQt6
+PyQt6-Charts
+numpy

--- a/run_app.py
+++ b/run_app.py
@@ -1,0 +1,22 @@
+import subprocess
+import sys
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parent
+
+
+def update_repo():
+    """Pull the latest changes for the application repo."""
+    try:
+        subprocess.run(["git", "pull"], cwd=APP_DIR, check=True)
+    except Exception as exc:
+        print(f"Repository update failed: {exc}")
+
+
+def main():
+    update_repo()
+    subprocess.run([sys.executable, str(APP_DIR / "pawgress.py"), *sys.argv[1:]], cwd=APP_DIR)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `.gitignore` for caches and SQLite data
- document running and updating in README
- list dependencies in `requirements.txt`
- add `run_app.py` to auto-update the repository before running the app

## Testing
- `python -m py_compile run_app.py pawgress.py mb_world_tracker.py`

------
https://chatgpt.com/codex/tasks/task_e_68438b5c1fcc8329ac717a457bd9f3fc