### PR TITLE
Add command line launcher and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,61 @@
-# Pawgress App
+# Pawgress App 🐾
 
-This repository provides a standalone PyQt6 desktop application used to track
-animal health data and simple project tasks.  It can be placed alongside your
-Unreal Engine `.uproject` file so the application is version controlled with
-the rest of the project.
+Pawgress is a lightweight PyQt6 desktop application for tracking animal health data and simple project tasks. Keep it next to your Unreal Engine `.uproject` so everything stays under version control.
 
-## Requirements
+## Features
 
-Install the Python dependencies with:
+- Log health notes and schedules
+- Manage project TODO items
+- Cross‑platform Python app
+
+## Quick Start
+
+Clone this repository and launch the helper script. It creates a local Python environment, installs dependencies and starts the program.
+
+### Windows
+```cmd
+start_app.bat
+```
+
+### macOS / Linux
+```bash
+./start_app.sh
+```
+
+The first run may take a little while as packages are installed. Subsequent launches will start the app immediately.
+
+## Manual Setup
+
+If you prefer to handle the environment yourself:
 
 ```bash
 pip install -r requirements.txt
-```
-
-## Running
-
-Use the `run_app.py` helper which automatically pulls the latest changes from
-the repository and then launches the main application:
-
-```bash
 python run_app.py
 ```
 
-The main application code lives in `pawgress.py`.
-
-## Updating
-
-`run_app.py` performs a `git pull` on startup so the application stays in sync
-with the repository whenever it is launched.
+`run_app.py` automatically pulls the latest changes before running `pawgress.py`.
 
 ## Building a Standalone Executable
 
-You can package the application as a single executable on any platform using
-[PyInstaller](https://pyinstaller.org/). First install PyInstaller:
+Install [PyInstaller](https://pyinstaller.org/):
 
 ```bash
 pip install pyinstaller
 ```
 
-Then run the provided `build.py` script which wraps the PyInstaller command:
+Then execute the build script:
 
 ```bash
 python build.py
 ```
 
-After completion, the standalone binary will be available inside the `dist`
-folder. Run the binary directly on your platform (Windows, macOS or Linux) with
-the same interface and functionality as running `python run_app.py`.
+After completion, the standalone binary appears in the `dist` folder.
 
-Note that executables must be built separately on each operating system.
+## Updating
+
+The application performs a `git pull` on startup through `run_app.py`, keeping it up to date with the repository.
+
+---
+
+Enjoy using Pawgress! 🐾
+

--- a/build.py
+++ b/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import subprocess
 from pathlib import Path
 import sys

--- a/mb_world_tracker.py
+++ b/mb_world_tracker.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 import sqlite3
 from PyQt6.QtWidgets import (

--- a/pawgress.py
+++ b/pawgress.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import numpy as np
 import subprocess

--- a/run_app.py
+++ b/run_app.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import subprocess
 import sys
 from pathlib import Path

--- a/start_app.bat
+++ b/start_app.bat
@@ -1,0 +1,11 @@
+@echo off
+setlocal
+set APP_DIR=%~dp0
+cd /d %APP_DIR%
+if not exist ".venv" (
+    python -m venv .venv
+)
+call .venv\Scripts\activate.bat
+pip install -r requirements.txt
+python run_app.py %*
+

--- a/start_app.sh
+++ b/start_app.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Simple launcher for the Pawgress application
+set -e
+
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$APP_DIR"
+
+if [ ! -d ".venv" ]; then
+    python3 -m venv .venv
+fi
+
+source .venv/bin/activate
+pip install -r requirements.txt
+
+python run_app.py "$@"
+


### PR DESCRIPTION
## Summary
- add cross-platform `start_app` scripts
- make Python scripts executable with shebang lines
- refresh README with clearer instructions

## Testing
- `python -m py_compile build.py run_app.py pawgress.py mb_world_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_68438debb8148329a641248f64acbcf6